### PR TITLE
Add support for endpoint-centric APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ More sample projects will be added as the framework develops.
 
 ## What's new
 
+### New in 3.0.0 
+- Add OnTransformModel delegate to allow the model to be transformed before validation (This is useful when using endpoint-centric APIs)
+- Major change because it changes the signature of the public IValidationProvider interface.
+
+### New in 2.0.0
+- Add net7.0 target framework.
+
 ### New in 1.8.0
 - Use `Services.TryAddScoped` instead of `Services.AddScoped` for validators, in case 
   the consuming app has already registered validators with a different lifetime.

--- a/Source/Lib/Directory.Build.props
+++ b/Source/Lib/Directory.Build.props
@@ -15,7 +15,7 @@
 
 		<PackageProjectUrl>https://github.com/mrpmorris/blazor-validation</PackageProjectUrl>
 		<PackageIconUrl />
-		<RepositoryUrl>https://github.com/mrpmorris/blazor-validation</RepositoryUrl>
+		<RepositoryUrl>https://github.com/mrpmorris/blazor-validation.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<LangVersion>latest</LangVersion>
 		<RazorLangVersion>3.0</RazorLangVersion>

--- a/Source/Lib/Directory.Build.props
+++ b/Source/Lib/Directory.Build.props
@@ -2,9 +2,9 @@
 
 	<PropertyGroup>
 
-		<Version>2.0.0</Version>
-		<AssemblyVersion>2.0.0.0</AssemblyVersion>
-		<FileVersion>2.0.0.0</FileVersion>
+		<Version>3.0.0</Version>
+		<AssemblyVersion>3.0.0.0</AssemblyVersion>
+		<FileVersion>3.0.0.0</FileVersion>
 
 		<Authors>Peter Morris</Authors>
 		<Company />
@@ -17,17 +17,16 @@
 		<PackageIconUrl />
 		<RepositoryUrl>https://github.com/mrpmorris/blazor-validation</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-
-		<AssemblyOriginatorKeyFile>MrPMorris.snk</AssemblyOriginatorKeyFile>
-		<SignAssembly>true</SignAssembly>
-		<DelaySign>false</DelaySign>
-
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-
+		<LangVersion>latest</LangVersion>
+		<RazorLangVersion>3.0</RazorLangVersion>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<PropertyGroup Condition="'$(Configuration)'=='Release'">
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<AssemblyOriginatorKeyFile>MrPMorris.snk</AssemblyOriginatorKeyFile>
+		<SignAssembly>true</SignAssembly>
+		<DelaySign>true</DelaySign>
 	</PropertyGroup>
 
 </Project>

--- a/Source/Lib/Morris.Blazor.FluentValidation/Morris.Blazor.FluentValidation.csproj
+++ b/Source/Lib/Morris.Blazor.FluentValidation/Morris.Blazor.FluentValidation.csproj
@@ -12,7 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentValidation" Version="11.4.0" />
+		<PackageReference Include="FluentValidation" Version="11.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Lib/Morris.Blazor.Validation/DataAnnotationsValidatorProvider.cs
+++ b/Source/Lib/Morris.Blazor.Validation/DataAnnotationsValidatorProvider.cs
@@ -6,10 +6,13 @@ namespace Morris.Blazor.Validation
 {
 	public class DataAnnotationsValidatorProvider : IValidationProvider
 	{
-		public void InitializeEditContext(
+		public void InitializeEditContext
+		(
 			EditContext editContext,
 			IServiceProvider serviceProvider,
-			ValidationProperties properties)
+			ValidationProperties properties,
+			Func<object, object> transformModel = null
+		)
 		{
 #if NET7_0_OR_GREATER
 			editContext.EnableDataAnnotationsValidation(serviceProvider);

--- a/Source/Lib/Morris.Blazor.Validation/IValidationProvider.cs
+++ b/Source/Lib/Morris.Blazor.Validation/IValidationProvider.cs
@@ -5,6 +5,12 @@ namespace Morris.Blazor.Validation
 {
 	public interface IValidationProvider
 	{
-		void InitializeEditContext(EditContext editContext, IServiceProvider serviceProvider, ValidationProperties properties);
+		void InitializeEditContext
+		(
+			EditContext editContext, 
+			IServiceProvider serviceProvider, 
+			ValidationProperties properties,
+			Func<object, object> transformModel = null
+		);
 	}
 }

--- a/Source/Lib/Morris.Blazor.Validation/Morris.Blazor.Validation.csproj
+++ b/Source/Lib/Morris.Blazor.Validation/Morris.Blazor.Validation.csproj
@@ -2,8 +2,6 @@
 
 	<PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<LangVersion>10</LangVersion>
-		<RazorLangVersion>3.0</RazorLangVersion>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<PackageId>Morris.Blazor.Validation</PackageId>
 		<Product>Morris.Blazor.Validation</Product>

--- a/Source/Lib/Morris.Blazor.Validation/Validate.cs
+++ b/Source/Lib/Morris.Blazor.Validation/Validate.cs
@@ -18,6 +18,8 @@ namespace Morris.Blazor.Validation
 
 		[Inject]
 		IServiceProvider ServiceProvider { get; set; }
+		[Parameter]
+		public Func<object, object> OnTransformModel { get; set; } = null;
 
 		public override async Task SetParametersAsync(ParameterView parameters)
 		{
@@ -39,7 +41,7 @@ namespace Morris.Blazor.Validation
 			foreach (Type providerType in Repository.All)
 			{
 				var validationProvider = (IValidationProvider)ServiceProvider.GetService(providerType);
-				validationProvider.InitializeEditContext(CurrentEditContext, ServiceProvider, ValidationProperties);
+				validationProvider.InitializeEditContext(CurrentEditContext, ServiceProvider, ValidationProperties, OnTransformModel);
 			}
 		}
 	}

--- a/Source/Samples/02-FluentValidation/FluentValidationSample/Pages/Index.razor
+++ b/Source/Samples/02-FluentValidation/FluentValidationSample/Pages/Index.razor
@@ -5,7 +5,7 @@
 @using Morris.Blazor.FluentValidation
 
 <EditForm Model=@Person OnSubmit=SubmitForm>
-	<Morris.Blazor.Validation.Validate ValidationProperties=@(ValidationProperties.Set.FluentValidator<PersonValidator>())/>
+	<Morris.Blazor.Validation.Validate ValidationProperties=@(ValidationProperties.Set.FluentValidator<PersonValidator>()) OnTransformModel=OnTransformModel />
 	<div class="mb-2 row">
 		<div class="col-3">
 			<label>Salutation</label>
@@ -74,6 +74,13 @@
 @code{
 	Models.Person Person = new Models.Person();
 
+	private object OnTransformModel(object model)
+	{
+		// Confirm that the model is of the expected type
+		// Do transformations here
+		// return the transformed model
+        return model;
+    }
 	void SubmitForm(EditContext editContext)
 	{
 		editContext.ValidateObjectTree();


### PR DESCRIPTION
With endpoint-centric APIs one may want to bind a form to a EditModel and validate it against various Commands.

To support that this PR adds the optional OnTransformModel parameter that takes a delegate.   The EditContext.Model will be passed to the delegate and it should return the relevant model.